### PR TITLE
Add dependency on get-config job for destroy-dev and destroy-stage

### DIFF
--- a/.github/workflows/destroy-app.yml
+++ b/.github/workflows/destroy-app.yml
@@ -14,6 +14,7 @@ jobs:
 
   destroy-dev:
     name: Destroy Develop
+    needs: [get-config]
     uses: ./.github/workflows/destroy-common.yml
     with:
       environment: dev
@@ -28,6 +29,7 @@ jobs:
 
   destroy-stage:
     name: Destroy Stage
+    needs: [get-config]
     uses: ./.github/workflows/destroy-common.yml
     with:
       environment: stage


### PR DESCRIPTION
## Overview (Required)

This pull request adds a dependency on the `get-config` job for the `destroy-dev` and `destroy-stage` jobs in the GitHub Actions workflow.

## Changes (Required)

- ### Addition of dependency on get-config job
  - Added `needs: [get-config]` to the `destroy-dev` job
  - Added `needs: [get-config]` to the `destroy-stage` job

## Review Priority (Required)

- [ ] Urgent (Review needed within the day)
- [x] High (Review needed within 2 business days)
- [ ] Medium (Review needed within a week)
- [ ] Low (Review when you have time)

## Related Issues/Projects

- Issues

- Projects

## Breaking Changes (Required)

- [ ] Yes (Describe details below)
- [x] No

## Impact Scope (Required)

- [ ] UI changes
- [ ] Database changes
- [ ] API changes
- [ ] Configuration changes
- [ ] Environment variable changes
- [x] None (Code cleanup)

## Testing

### Build/Test

- [ ] `nps build` completes successfully
- [ ] `nps docker.build` completes successfully
- [ ] `nps test` passes

### Functionality Check

- [ ] Verified in local environment
- [ ] Verified in staging environment

## Screenshots

<!--
  If there are UI changes, share before/after using one of the following methods:

  1. Screenshots
  2. GIF, MP4
-->

## Deployment Steps

- [x] Can be handled with the usual deployment steps
- [ ] Special steps required (Describe details below)

## Notes

- Ensure that the `get-config` job is defined and functioning correctly before merging this PR.